### PR TITLE
Add nationwide youth club & coach directory scaffold with submissions, claims, reviews, and admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# SoccerDadHQ Directory Expansion (Scaffold)
+
+This repository now includes a mobile-first scaffold for:
+- Nationwide club directory
+- Nationwide coach directory
+- Club/coach submissions (pending review)
+- Club/coach claims (pending/approved/rejected)
+- Anonymous reviews with moderation queue
+- Admin moderation interface
+- Advertising placeholders
+- Payment placeholder for yearly club claim fee
+
+## Structure
+
+- `backend/schema.sql` — normalized schema for clubs, coaches, claims, reviews, ads.
+- `public/` — static app pages and shared JS/CSS.
+- `data/seed.js` — starter in-memory data consumed by frontend.
+
+## Run locally
+
+Because this is framework-agnostic and static, open `public/index.html` directly in a browser, or serve it:
+
+```bash
+python3 -m http.server 8080 -d public
+```
+
+Then visit `http://localhost:8080`.

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,147 @@
+-- SoccerDadHQ directory schema scaffold
+-- Dialect: PostgreSQL-compatible SQL
+
+CREATE TABLE clubs (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE NOT NULL,
+  city TEXT NOT NULL,
+  state CHAR(2) NOT NULL,
+  zip_code TEXT NOT NULL,
+  website TEXT,
+  phone TEXT,
+  email TEXT,
+  logo_url TEXT,
+  leagues TEXT[] DEFAULT '{}',
+  gender_programs TEXT[] DEFAULT '{}',
+  age_groups TEXT[] DEFAULT '{}',
+  tryout_info TEXT,
+  registration_link TEXT,
+  description TEXT,
+  social_links JSONB DEFAULT '{}'::jsonb,
+  is_claimed BOOLEAN DEFAULT FALSE,
+  claim_fee_status TEXT DEFAULT 'not_configured',
+  claim_fee_renewal_date DATE,
+  moderation_status TEXT NOT NULL DEFAULT 'approved',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE coaches (
+  id UUID PRIMARY KEY,
+  club_id UUID REFERENCES clubs(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE NOT NULL,
+  city TEXT NOT NULL,
+  state CHAR(2) NOT NULL,
+  bio TEXT,
+  age_groups_coached TEXT[] DEFAULT '{}',
+  leagues TEXT[] DEFAULT '{}',
+  gender_programs TEXT[] DEFAULT '{}',
+  contact_links JSONB DEFAULT '{}'::jsonb,
+  is_claimed BOOLEAN DEFAULT FALSE,
+  moderation_status TEXT NOT NULL DEFAULT 'approved',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE club_submissions (
+  id UUID PRIMARY KEY,
+  club_name TEXT NOT NULL,
+  city TEXT NOT NULL,
+  state CHAR(2) NOT NULL,
+  zip_code TEXT NOT NULL,
+  website TEXT,
+  contact_email TEXT,
+  leagues TEXT[] DEFAULT '{}',
+  gender_programs TEXT[] DEFAULT '{}',
+  age_groups TEXT[] DEFAULT '{}',
+  notes TEXT,
+  moderation_status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE coach_submissions (
+  id UUID PRIMARY KEY,
+  coach_name TEXT NOT NULL,
+  club_name TEXT,
+  city TEXT NOT NULL,
+  state CHAR(2) NOT NULL,
+  bio TEXT,
+  age_groups_coached TEXT[] DEFAULT '{}',
+  leagues TEXT[] DEFAULT '{}',
+  gender_programs TEXT[] DEFAULT '{}',
+  notes TEXT,
+  moderation_status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE club_claims (
+  id UUID PRIMARY KEY,
+  club_id UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+  claimant_name TEXT NOT NULL,
+  role_title TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT,
+  club_website TEXT,
+  message_proof TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  reviewed_by TEXT,
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE coach_claims (
+  id UUID PRIMARY KEY,
+  coach_id UUID NOT NULL REFERENCES coaches(id) ON DELETE CASCADE,
+  claimant_name TEXT NOT NULL,
+  role_title TEXT NOT NULL,
+  email TEXT NOT NULL,
+  phone TEXT,
+  message_proof TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  reviewed_by TEXT,
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE club_reviews (
+  id UUID PRIMARY KEY,
+  club_id UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+  reviewer_user_id UUID NOT NULL,
+  is_anonymous_public BOOLEAN NOT NULL DEFAULT TRUE,
+  communication SMALLINT NOT NULL CHECK (communication BETWEEN 1 AND 5),
+  player_development SMALLINT NOT NULL CHECK (player_development BETWEEN 1 AND 5),
+  organization SMALLINT NOT NULL CHECK (organization BETWEEN 1 AND 5),
+  coaching_quality SMALLINT NOT NULL CHECK (coaching_quality BETWEEN 1 AND 5),
+  value_for_money SMALLINT NOT NULL CHECK (value_for_money BETWEEN 1 AND 5),
+  overall_experience SMALLINT NOT NULL CHECK (overall_experience BETWEEN 1 AND 5),
+  review_text TEXT,
+  moderation_status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE coach_reviews (
+  id UUID PRIMARY KEY,
+  coach_id UUID NOT NULL REFERENCES coaches(id) ON DELETE CASCADE,
+  reviewer_user_id UUID NOT NULL,
+  is_anonymous_public BOOLEAN NOT NULL DEFAULT TRUE,
+  communication SMALLINT NOT NULL CHECK (communication BETWEEN 1 AND 5),
+  player_development SMALLINT NOT NULL CHECK (player_development BETWEEN 1 AND 5),
+  game_knowledge SMALLINT NOT NULL CHECK (game_knowledge BETWEEN 1 AND 5),
+  fairness SMALLINT NOT NULL CHECK (fairness BETWEEN 1 AND 5),
+  motivation_leadership SMALLINT NOT NULL CHECK (motivation_leadership BETWEEN 1 AND 5),
+  overall_experience SMALLINT NOT NULL CHECK (overall_experience BETWEEN 1 AND 5),
+  review_text TEXT,
+  moderation_status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE ad_slots (
+  id UUID PRIMARY KEY,
+  slot_key TEXT UNIQUE NOT NULL,
+  slot_name TEXT NOT NULL,
+  location_description TEXT NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/data/seed.js
+++ b/data/seed.js
@@ -1,0 +1,72 @@
+window.SEED = {
+  clubs: [
+    {
+      id: 'club-1',
+      name: 'Metro United SC',
+      city: 'Austin',
+      state: 'TX',
+      zip: '78701',
+      website: 'https://example.com/metro',
+      phone: '(555) 555-1000',
+      email: 'info@metrounited.example',
+      logo: '',
+      leagues: ['ECNL', 'MLS NEXT'],
+      genders: ['Boys', 'Girls'],
+      ages: ['U11', 'U12', 'U13', 'U14', 'U15', 'U16', 'U17', 'U18', 'U19'],
+      tryoutInfo: 'Tryouts start May 15.',
+      registrationLink: 'https://example.com/metro/tryouts',
+      description: 'Competitive youth club focused on long-term player development.',
+      social: { instagram: '#', facebook: '#' },
+      rating: 4.4
+    },
+    {
+      id: 'club-2',
+      name: 'Lakeview FC',
+      city: 'Columbus',
+      state: 'OH',
+      zip: '43004',
+      website: 'https://example.com/lakeview',
+      phone: '(555) 555-2000',
+      email: 'hello@lakeview.example',
+      logo: '',
+      leagues: ['NPL', 'USYS', 'Local/Other'],
+      genders: ['Coed'],
+      ages: ['U8', 'U9', 'U10', 'U11', 'U12', 'U13', 'U14'],
+      tryoutInfo: 'Rolling evaluations every month.',
+      registrationLink: 'https://example.com/lakeview/register',
+      description: 'Family-first club with strong coaching standards and clear communication.',
+      social: { x: '#', facebook: '#' },
+      rating: 4.1
+    }
+  ],
+  coaches: [
+    {
+      id: 'coach-1',
+      name: 'Jordan Ellis',
+      clubId: 'club-1',
+      club: 'Metro United SC',
+      city: 'Austin',
+      state: 'TX',
+      bio: 'USSF B licensed coach with 10 years in elite youth pathways.',
+      ages: ['U14', 'U15', 'U16'],
+      leagues: ['ECNL'],
+      genders: ['Girls'],
+      contact: { linkedin: '#' },
+      rating: 4.6
+    },
+    {
+      id: 'coach-2',
+      name: 'Casey Morgan',
+      clubId: 'club-2',
+      club: 'Lakeview FC',
+      city: 'Columbus',
+      state: 'OH',
+      bio: 'Former college player focused on technical and confidence development.',
+      ages: ['U10', 'U11', 'U12'],
+      leagues: ['USYS'],
+      genders: ['Coed'],
+      contact: { instagram: '#' },
+      rating: 4.2
+    }
+  ]
+};

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Admin</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='admin'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='clubs.html'>Clubs</a><a href='coaches.html'>Coaches</a></nav></header>
+<main>
+<div class='card'><h2>Admin Moderation</h2><p class='muted'>Approve/reject submissions, claims, and reviews. Marking claimed/unclaimed and editing/removing are represented through moderated records in this scaffold.</p></div>
+<div id='admin-panels'></div>
+</main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,319 @@
+const STATES = ['AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA','HI','ID','IL','IN','IA','KS','KY','LA','ME','MD','MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ','NM','NY','NC','ND','OH','OK','OR','PA','RI','SC','SD','TN','TX','UT','VT','VA','WA','WV','WI','WY'];
+const LEAGUES = ['ECNL','ECNL RL','GA','DPL','MLS NEXT','NAL','NPL','USYS','EDP','Local/Other'];
+const AGES = Array.from({length: 12}, (_, i) => `U${i+8}`);
+
+const store = {
+  get(key, fallback=[]) { return JSON.parse(localStorage.getItem(key) || JSON.stringify(fallback)); },
+  set(key, value) { localStorage.setItem(key, JSON.stringify(value)); }
+};
+
+function pageName() {
+  return document.body.dataset.page;
+}
+
+function adSlots(target) {
+  target.innerHTML = `
+    <div class="ad"><strong>Advertise with SoccerDadHQ</strong><div class="muted">Top banner placeholder</div></div>
+    <div class="ad"><strong>Sponsored Placement</strong><div class="muted">In-list sponsored placement placeholder</div></div>
+    <div class="ad"><strong>Newsletter Sponsor</strong><div class="muted">Newsletter sponsorship placeholder</div></div>
+  `;
+}
+
+function options(list, selected='') {
+  return list.map(v => `<option value="${v}" ${selected===v?'selected':''}>${v}</option>`).join('');
+}
+
+function clubsData() {
+  return store.get('clubs', window.SEED.clubs);
+}
+
+function coachesData() {
+  return store.get('coaches', window.SEED.coaches);
+}
+
+function initClubDirectory() {
+  const list = document.getElementById('club-list');
+  const filters = document.getElementById('club-filters');
+  const ad = document.getElementById('club-ads');
+  adSlots(ad);
+
+  filters.state.innerHTML = `<option value="">Any</option>${options(STATES)}`;
+  filters.league.innerHTML = `<option value="">Any</option>${options(LEAGUES)}`;
+  filters.age.innerHTML = `<option value="">Any</option>${options(AGES)}`;
+
+  const render = () => {
+    const term = filters.q.value.toLowerCase();
+    const state = filters.state.value;
+    const city = filters.city.value.toLowerCase();
+    const zip = filters.zip.value.trim();
+    const gender = filters.gender.value;
+    const league = filters.league.value;
+    const age = filters.age.value;
+
+    const rows = clubsData().filter(c =>
+      (!term || c.name.toLowerCase().includes(term)) &&
+      (!state || c.state === state) &&
+      (!city || c.city.toLowerCase().includes(city)) &&
+      (!zip || c.zip.startsWith(zip)) &&
+      (!gender || c.genders.includes(gender)) &&
+      (!league || c.leagues.includes(league)) &&
+      (!age || c.ages.includes(age))
+    );
+
+    list.innerHTML = rows.map(c => `
+      <div class="listing">
+        <h3>${c.name}</h3>
+        <div class="muted">${c.city}, ${c.state} ${c.zip} · <span class="star">★ ${c.rating.toFixed(1)}</span></div>
+        <div>${c.leagues.map(l=>`<span class='badge'>${l}</span>`).join('')}</div>
+        <div class="actions">
+          <a class="badge" href="club-profile.html?id=${c.id}">View Profile</a>
+          <a class="badge" href="submit-club.html">Submit Missing Club</a>
+        </div>
+      </div>
+    `).join('') || '<div class="notice">No clubs match your filters.</div>';
+  };
+
+  filters.addEventListener('input', render);
+  render();
+}
+
+function initCoachDirectory() {
+  const list = document.getElementById('coach-list');
+  const filters = document.getElementById('coach-filters');
+  const ad = document.getElementById('coach-ads');
+  adSlots(ad);
+
+  filters.state.innerHTML = `<option value="">Any</option>${options(STATES)}`;
+  filters.league.innerHTML = `<option value="">Any</option>${options(LEAGUES)}`;
+  filters.age.innerHTML = `<option value="">Any</option>${options(AGES)}`;
+
+  const render = () => {
+    const name = filters.name.value.toLowerCase();
+    const club = filters.club.value.toLowerCase();
+    const state = filters.state.value;
+    const city = filters.city.value.toLowerCase();
+    const gender = filters.gender.value;
+    const league = filters.league.value;
+    const age = filters.age.value;
+
+    const rows = coachesData().filter(c =>
+      (!name || c.name.toLowerCase().includes(name)) &&
+      (!club || c.club.toLowerCase().includes(club)) &&
+      (!state || c.state === state) &&
+      (!city || c.city.toLowerCase().includes(city)) &&
+      (!gender || c.genders.includes(gender)) &&
+      (!league || c.leagues.includes(league)) &&
+      (!age || c.ages.includes(age))
+    );
+
+    list.innerHTML = rows.map(c => `
+      <div class="listing">
+        <h3>${c.name}</h3>
+        <div class="muted">${c.club} · ${c.city}, ${c.state} · <span class="star">★ ${c.rating.toFixed(1)}</span></div>
+        <p>${c.bio}</p>
+        <div class="actions">
+          <a class="badge" href="coach-profile.html?id=${c.id}">View Profile</a>
+          <a class="badge" href="coach-profile.html?id=${c.id}#rate">Rate a Coach</a>
+        </div>
+      </div>
+    `).join('') || '<div class="notice">No coaches match your filters.</div>';
+  };
+
+  filters.addEventListener('input', render);
+  render();
+}
+
+function param(name) { return new URLSearchParams(location.search).get(name); }
+
+function savePending(form, key, mapper) {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const fd = new FormData(form);
+    const item = mapper(fd);
+    const rows = store.get(key, []);
+    rows.push(item);
+    store.set(key, rows);
+    form.reset();
+    alert('Saved as pending review.');
+  });
+}
+
+function initSubmitClub() {
+  const form = document.getElementById('submit-club-form');
+  form.state.innerHTML = options(STATES);
+  savePending(form, 'pendingClubSubmissions', (fd) => ({
+    id: crypto.randomUUID(),
+    clubName: fd.get('clubName'), city: fd.get('city'), state: fd.get('state'), zip: fd.get('zip'),
+    website: fd.get('website'), contactEmail: fd.get('contactEmail'), leagues: fd.getAll('leagues'),
+    genders: fd.getAll('genders'), ages: fd.getAll('ages'), notes: fd.get('notes'), status: 'pending', createdAt: new Date().toISOString()
+  }));
+}
+
+function initSubmitCoach() {
+  const form = document.getElementById('submit-coach-form');
+  form.state.innerHTML = options(STATES);
+  savePending(form, 'pendingCoachSubmissions', (fd) => ({
+    id: crypto.randomUUID(),
+    coachName: fd.get('coachName'), club: fd.get('club'), city: fd.get('city'), state: fd.get('state'), bio: fd.get('bio'),
+    ages: fd.getAll('ages'), leagues: fd.getAll('leagues'), genders: fd.getAll('genders'), notes: fd.get('notes'),
+    status: 'pending', createdAt: new Date().toISOString()
+  }));
+}
+
+function initClubProfile() {
+  const id = param('id');
+  const club = clubsData().find(c => c.id === id);
+  const root = document.getElementById('club-profile');
+  if (!club) return root.innerHTML = '<p>Club not found.</p>';
+  root.innerHTML = `
+    <div class="card">
+      <h2>${club.name}</h2>
+      <div class="muted">${club.city}, ${club.state} ${club.zip}</div>
+      <p>${club.description}</p>
+      <p><strong>Website:</strong> ${club.website} | <strong>Phone:</strong> ${club.phone} | <strong>Email:</strong> ${club.email}</p>
+      <p><strong>Tryouts:</strong> ${club.tryoutInfo}</p>
+      <p><strong>Yearly Club Claim Fee:</strong> Placeholder UI (payment system not connected).</p>
+      <div class="actions">
+        <a class="badge" href="claim-club.html?clubId=${club.id}">Claim This Club</a>
+      </div>
+      <div class="ad"><strong>Profile Page Sponsor</strong><div class="muted">Sponsor area placeholder</div></div>
+    </div>
+  `;
+
+  initReviews('club', club.id, 'club-reviews');
+}
+
+function initCoachProfile() {
+  const id = param('id');
+  const coach = coachesData().find(c => c.id === id);
+  const root = document.getElementById('coach-profile');
+  if (!coach) return root.innerHTML = '<p>Coach not found.</p>';
+  root.innerHTML = `
+    <div class="card">
+      <h2>${coach.name}</h2>
+      <div class="muted">${coach.club} · ${coach.city}, ${coach.state}</div>
+      <p>${coach.bio}</p>
+      <div class="actions">
+        <a class="badge" href="claim-coach.html?coachId=${coach.id}">Claim This Coach Profile</a>
+        <a class="badge" href="#rate">Rate a Coach</a>
+      </div>
+      <div class="ad"><strong>Profile Page Sponsor</strong><div class="muted">Sponsor area placeholder</div></div>
+    </div>
+  `;
+
+  initReviews('coach', coach.id, 'coach-reviews');
+}
+
+function initClubClaim() {
+  const clubId = param('clubId');
+  const club = clubsData().find(c => c.id === clubId);
+  const form = document.getElementById('claim-club-form');
+  form.clubId.value = clubId || '';
+  document.getElementById('club-claim-title').textContent = club ? `Claim ${club.name}` : 'Claim Club';
+  savePending(form, 'pendingClubClaims', (fd) => ({
+    id: crypto.randomUUID(), clubId: fd.get('clubId'), name: fd.get('name'), role: fd.get('role'), email: fd.get('email'),
+    phone: fd.get('phone'), website: fd.get('website'), message: fd.get('message'), status: 'pending', createdAt: new Date().toISOString()
+  }));
+}
+
+function initCoachClaim() {
+  const coachId = param('coachId');
+  const coach = coachesData().find(c => c.id === coachId);
+  const form = document.getElementById('claim-coach-form');
+  form.coachId.value = coachId || '';
+  document.getElementById('coach-claim-title').textContent = coach ? `Claim ${coach.name}` : 'Claim Coach Profile';
+  savePending(form, 'pendingCoachClaims', (fd) => ({
+    id: crypto.randomUUID(), coachId: fd.get('coachId'), name: fd.get('name'), role: fd.get('role'), email: fd.get('email'),
+    phone: fd.get('phone'), message: fd.get('message'), status: 'pending', createdAt: new Date().toISOString()
+  }));
+}
+
+function avg(values) { return (values.reduce((a,b)=>a+b,0)/values.length).toFixed(1); }
+function initReviews(type, entityId, containerId) {
+  const key = type === 'club' ? 'clubReviews' : 'coachReviews';
+  const queueKey = type === 'club' ? 'pendingClubReviews' : 'pendingCoachReviews';
+  const wrap = document.getElementById(containerId);
+  const approved = store.get(key, []).filter(r => r.entityId === entityId && r.status === 'approved');
+  const stars = approved.length ? avg(approved.map(r => r.overallExperience)) : '—';
+  wrap.innerHTML = `
+    <div class='card' id='rate'>
+      <h3>Ratings & Reviews <span class='star'>★ ${stars}</span></h3>
+      <p class='muted'>Reviews are anonymous publicly and require admin approval.</p>
+      ${approved.map(r => `<div class='listing'><strong>Anonymous Parent</strong><p>${r.text || 'No comment.'}</p></div>`).join('') || '<p class="muted">No approved reviews yet.</p>'}
+      <form id='review-form'>
+        <label>Overall experience (1-5)<input name='overallExperience' type='number' min='1' max='5' required /></label>
+        <label>Comments<textarea name='text'></textarea></label>
+        <button type='submit'>Submit Review</button>
+      </form>
+    </div>
+  `;
+  wrap.querySelector('#review-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    const queue = store.get(queueKey, []);
+    queue.push({ id: crypto.randomUUID(), entityId, overallExperience: Number(fd.get('overallExperience')), text: fd.get('text'), status: 'pending' });
+    store.set(queueKey, queue);
+    alert('Thanks! Your review is pending admin moderation.');
+    e.target.reset();
+  });
+}
+
+function initAdmin() {
+  const root = document.getElementById('admin-panels');
+  const groups = [
+    ['Club submissions', 'pendingClubSubmissions'],
+    ['Coach submissions', 'pendingCoachSubmissions'],
+    ['Club claims', 'pendingClubClaims'],
+    ['Coach claims', 'pendingCoachClaims'],
+    ['Club reviews', 'pendingClubReviews'],
+    ['Coach reviews', 'pendingCoachReviews']
+  ];
+  root.innerHTML = groups.map(([title, key]) => {
+    const rows = store.get(key, []);
+    return `
+      <div class='card'>
+        <h3>${title}</h3>
+        ${rows.map(r => `<div class='listing'><pre>${JSON.stringify(r, null, 2)}</pre>
+          <div class='actions'>
+            <button data-key='${key}' data-id='${r.id}' data-action='approved'>Approve</button>
+            <button data-key='${key}' data-id='${r.id}' data-action='rejected'>Reject</button>
+          </div>
+        </div>`).join('') || '<p class="muted">No pending items.</p>'}
+      </div>
+    `;
+  }).join('');
+
+  root.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-key]');
+    if (!btn) return;
+    const rows = store.get(btn.dataset.key, []);
+    const next = rows.map(r => r.id === btn.dataset.id ? {...r, status: btn.dataset.action} : r);
+    store.set(btn.dataset.key, next);
+    if (btn.dataset.action === 'approved' && btn.dataset.key === 'pendingClubReviews') {
+      const approved = store.get('clubReviews', []);
+      const item = next.find(r => r.id === btn.dataset.id);
+      approved.push({...item, status: 'approved'});
+      store.set('clubReviews', approved);
+    }
+    if (btn.dataset.action === 'approved' && btn.dataset.key === 'pendingCoachReviews') {
+      const approved = store.get('coachReviews', []);
+      const item = next.find(r => r.id === btn.dataset.id);
+      approved.push({...item, status: 'approved'});
+      store.set('coachReviews', approved);
+    }
+    initAdmin();
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const page = pageName();
+  if (page === 'clubs') initClubDirectory();
+  if (page === 'coaches') initCoachDirectory();
+  if (page === 'submit-club') initSubmitClub();
+  if (page === 'submit-coach') initSubmitCoach();
+  if (page === 'club-profile') initClubProfile();
+  if (page === 'coach-profile') initCoachProfile();
+  if (page === 'claim-club') initClubClaim();
+  if (page === 'claim-coach') initCoachClaim();
+  if (page === 'admin') initAdmin();
+});

--- a/public/claim-club.html
+++ b/public/claim-club.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Claim Club</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='claim-club'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='clubs.html'>Club Directory</a></nav></header>
+<main><div class='card'><h2 id='club-claim-title'>Claim Club</h2><p class='muted'>Claim requests are created as pending and require admin approval.</p>
+<form id='claim-club-form'>
+<input name='clubId' type='hidden'/> <label>Name<input name='name' required/></label><label>Role/title<input name='role' required/></label><label>Email<input name='email' type='email' required/></label><label>Phone<input name='phone'/></label><label>Club website<input name='website'/></label><label>Message/proof<textarea name='message'></textarea></label><button type='submit'>Submit Claim</button>
+</form></div></main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/claim-coach.html
+++ b/public/claim-coach.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Claim Coach</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='claim-coach'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='coaches.html'>Coach Directory</a></nav></header>
+<main><div class='card'><h2 id='coach-claim-title'>Claim Coach</h2><p class='muted'>Claim requests are created as pending and require admin approval.</p>
+<form id='claim-coach-form'>
+<input name='coachId' type='hidden'/> <label>Name<input name='name' required/></label><label>Role/title<input name='role' required/></label><label>Email<input name='email' type='email' required/></label><label>Phone<input name='phone'/></label><label>Message/proof<textarea name='message'></textarea></label><button type='submit'>Submit Claim</button>
+</form></div></main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/club-profile.html
+++ b/public/club-profile.html
@@ -1,0 +1,6 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Club Profile</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='club-profile'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='clubs.html'>Club Directory</a></nav></header>
+<main><div id='club-profile'></div><div id='club-reviews'></div></main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/clubs.html
+++ b/public/clubs.html
@@ -1,0 +1,19 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Club Directory</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='clubs'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='coaches.html'>Coach Directory</a><a href='submit-club.html'>Submit Club</a></nav></header>
+<main class='grid'>
+<section>
+  <div class='card'><h2>Club Directory</h2>
+    <form id='club-filters'>
+      <label>Club name<input name='q'/></label>
+      <div class='row'><label>City<input name='city'/></label><label>State<select name='state'></select></label></div>
+      <div class='row'><label>ZIP / Radius placeholder<input name='zip' placeholder='ZIP'/></label><label>Gender<select name='gender'><option value=''>Any</option><option>Boys</option><option>Girls</option><option>Coed</option></select></label></div>
+      <div class='row'><label>League<select name='league'></select></label><label>Age Group<select name='age'></select></label></div>
+    </form>
+  </div>
+  <div id='club-list'></div>
+</section>
+<aside id='club-ads'></aside>
+</main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/coach-profile.html
+++ b/public/coach-profile.html
@@ -1,0 +1,6 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Coach Profile</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='coach-profile'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='coaches.html'>Coach Directory</a></nav></header>
+<main><div id='coach-profile'></div><div id='coach-reviews'></div></main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/coaches.html
+++ b/public/coaches.html
@@ -1,0 +1,20 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Coach Directory</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='coaches'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='clubs.html'>Club Directory</a><a href='submit-coach.html'>Submit Coach</a></nav></header>
+<main class='grid'>
+<section>
+  <div class='card'><h2>Coach Directory</h2>
+    <form id='coach-filters'>
+      <label>Coach name<input name='name'/></label>
+      <label>Club<input name='club'/></label>
+      <div class='row'><label>City<input name='city'/></label><label>State<select name='state'></select></label></div>
+      <div class='row'><label>Gender<select name='gender'><option value=''>Any</option><option>Boys</option><option>Girls</option><option>Coed</option></select></label><label>League<select name='league'></select></label></div>
+      <label>Age Group<select name='age'></select></label>
+    </form>
+  </div>
+  <div id='coach-list'></div>
+</section>
+<aside id='coach-ads'></aside>
+</main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>SoccerDadHQ</title><link rel='stylesheet' href='styles.css'/></head>
+<body>
+<header><nav class='nav'><strong>SoccerDadHQ</strong><a href='clubs.html'>Club Directory</a><a href='coaches.html'>Coach Directory</a><a href='submit-club.html'>Submit Club</a><a href='submit-coach.html'>Submit Coach</a><a href='admin.html'>Admin</a></nav></header>
+<main>
+  <div class='card'>
+    <h1>Nationwide Youth Soccer Directory</h1>
+    <p>Browse clubs and coaches, submit missing listings, claim profiles, and leave moderated anonymous reviews.</p>
+    <div class='actions'>
+      <a class='badge' href='clubs.html'>Find Clubs</a>
+      <a class='badge' href='coaches.html'>Find Coaches</a>
+    </div>
+  </div>
+</main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,71 @@
+:root {
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --text: #10243e;
+  --muted: #5a6b7f;
+  --brand: #0d5bd7;
+  --line: #d8e0ea;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+header {
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+.nav {
+  max-width: 1100px;
+  margin: auto;
+  padding: 0.75rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.nav a { color: var(--brand); text-decoration: none; font-weight: 700; }
+main { max-width: 1100px; margin: 1rem auto; padding: 0 0.75rem; }
+.grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+@media (min-width: 900px) { .grid { grid-template-columns: 2fr 1fr; } }
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 1rem;
+}
+.listing {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+label { display: block; font-size: .9rem; margin-top: .5rem; }
+input, select, textarea, button {
+  width: 100%;
+  padding: .55rem;
+  margin-top: .25rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+button {
+  background: var(--brand);
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+.muted { color: var(--muted); font-size: .9rem; }
+.row { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; }
+.badge { background: #e9f0ff; color: #0a46a6; padding: .2rem .5rem; border-radius: 999px; font-size: .75rem; display: inline-block; margin-right: .35rem; }
+.ad { border: 1px dashed #6f86a8; background: #eff4ff; padding: .9rem; border-radius: 8px; margin-bottom: 1rem; }
+.star { color: #e29600; font-weight: 700; }
+.actions { display: flex; gap: .5rem; margin-top: .65rem; }
+.actions a, .actions button { width: auto; text-decoration: none; padding: .45rem .65rem; }
+.notice { background: #f0f8ff; border: 1px solid #b8d7ff; border-radius: 8px; padding: .6rem; }

--- a/public/submit-club.html
+++ b/public/submit-club.html
@@ -1,0 +1,15 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Submit Club</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='submit-club'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='clubs.html'>Club Directory</a></nav></header>
+<main><div class='card'><h2>Submit a Club</h2><p class='muted'>New submissions are saved as pending review.</p>
+<form id='submit-club-form'>
+<label>Club name<input name='clubName' required/></label><div class='row'><label>City<input name='city' required/></label><label>State<select name='state'></select></label></div>
+<label>ZIP<input name='zip' required/></label><label>Website<input name='website'/></label><label>Contact email<input name='contactEmail' type='email'/></label>
+<label>Leagues (multi-select with Ctrl/Cmd)<select name='leagues' multiple size='5'><option>ECNL</option><option>ECNL RL</option><option>GA</option><option>DPL</option><option>MLS NEXT</option><option>NAL</option><option>NPL</option><option>USYS</option><option>EDP</option><option>Local/Other</option></select></label>
+<label>Gender programs<select name='genders' multiple size='3'><option>Boys</option><option>Girls</option><option>Coed</option></select></label>
+<label>Age groups<select name='ages' multiple size='6'><option>U8</option><option>U9</option><option>U10</option><option>U11</option><option>U12</option><option>U13</option><option>U14</option><option>U15</option><option>U16</option><option>U17</option><option>U18</option><option>U19</option></select></label>
+<label>Notes<textarea name='notes'></textarea></label>
+<button type='submit'>Submit Club</button>
+</form></div></main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>

--- a/public/submit-coach.html
+++ b/public/submit-coach.html
@@ -1,0 +1,16 @@
+<!doctype html><html><head><meta charset='utf-8'/><meta name='viewport' content='width=device-width,initial-scale=1'/><title>Submit Coach</title><link rel='stylesheet' href='styles.css'/></head>
+<body data-page='submit-coach'>
+<header><nav class='nav'><a href='index.html'>SoccerDadHQ</a><a href='coaches.html'>Coach Directory</a></nav></header>
+<main><div class='card'><h2>Submit a Coach</h2><p class='muted'>New submissions are saved as pending review.</p>
+<form id='submit-coach-form'>
+<label>Coach name<input name='coachName' required/></label><label>Club<input name='club'/></label>
+<div class='row'><label>City<input name='city' required/></label><label>State<select name='state'></select></label></div>
+<label>Bio<textarea name='bio'></textarea></label>
+<label>Leagues<select name='leagues' multiple size='5'><option>ECNL</option><option>ECNL RL</option><option>GA</option><option>DPL</option><option>MLS NEXT</option><option>NAL</option><option>NPL</option><option>USYS</option><option>EDP</option><option>Local/Other</option></select></label>
+<label>Gender programs<select name='genders' multiple size='3'><option>Boys</option><option>Girls</option><option>Coed</option></select></label>
+<label>Age groups<select name='ages' multiple size='6'><option>U8</option><option>U9</option><option>U10</option><option>U11</option><option>U12</option><option>U13</option><option>U14</option><option>U15</option><option>U16</option><option>U17</option><option>U18</option><option>U19</option></select></label>
+<label>Notes<textarea name='notes'></textarea></label>
+<button type='submit'>Submit Coach</button>
+</form></div></main>
+<script src='../data/seed.js'></script><script src='app.js'></script>
+</body></html>


### PR DESCRIPTION
### Motivation
- Add a nationwide, mobile-first club and coach directory to SoccerDadHQ while preserving existing pages, layout, and styling.
- Provide a moderated workflow for user-submitted clubs/coaches, profile claims, and anonymous reviews so site data remains curated.
- Include basic admin tools and advertising placeholders to support future sponsorship and monetization without implementing payment integrations yet.

### Description
- Added a normalized backend schema scaffold at `backend/schema.sql` defining `clubs`, `coaches`, `*_submissions`, `*_claims`, `*_reviews`, and `ad_slots` with moderation and claim/payment metadata.
- Added a static, framework-agnostic frontend under `public/` including `index.html`, directory pages, profile pages, claim/submit forms, `admin.html`, shared `styles.css`, and `app.js` which implements filtering, submissions, claims, reviews, moderation, and ad placeholders.
- Added starter in-memory seed data at `data/seed.js` and local pending workflows that persist to `localStorage` (keys like `pendingClubSubmissions`, `pendingClubClaims`, `pendingClubReviews`) for a safe, review-first flow.
- Left a clear placeholder for yearly claim fee UI and schema metadata for later Stripe/payment wiring while ensuring claim forms are pre-bound to profiles via URL params (no re-search required).

### Testing
- Ran a JavaScript syntax check with `node --check public/app.js` which succeeded.
- Verified repository state and created a commit for the scaffold (files added under `backend/`, `public/`, and `data/`).
- Checked for optional automation dependency `playwright` with `python3` and found it unavailable in this environment (informational only, not blocking the scaffold).
- Manual browse/read of created files was used to validate page wiring and localStorage-based moderation flows (no end-to-end browser automation was run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdc3175ec8323af2b8c6deb0f8ff4)